### PR TITLE
fix(examples): Update trace property

### DIFF
--- a/quarkus-keycloak/src/main/resources/application.properties
+++ b/quarkus-keycloak/src/main/resources/application.properties
@@ -37,9 +37,7 @@ quarkus.hawtio.plugin.sample-plugin.module = ./plugin
 camel.context.name = SampleCamelQuarkus
 
 # Uncomment these properties to enable the Camel plugin Trace tab
-#camel.main.tracing = true
-#camel.main.backlogTracing = true
-#camel.main.useBreadcrumb = true
+#camel.trace.enabled = true
 
 quartz.cron = 0/10 * * * * ?
 quartz.repeatInterval = 10000

--- a/quarkus/src/main/resources/application.properties
+++ b/quarkus/src/main/resources/application.properties
@@ -34,9 +34,7 @@ quarkus.hawtio.plugin.sample-plugin.module = ./plugin
 camel.context.name = SampleCamelQuarkus
 
 # Uncomment these properties to enable the Camel plugin Trace tab
-#camel.main.tracing = true
-#camel.main.backlogTracing = true
-#camel.main.useBreadcrumb = true
+#camel.trace.enabled = true
 
 # Enable the Camel plugin Debug tab even in non-development environment
 quarkus.camel.debug.enabled = true

--- a/springboot-log4j2/src/main/resources/application.properties
+++ b/springboot-log4j2/src/main/resources/application.properties
@@ -20,9 +20,7 @@ logging.level.io.undertow=WARN
 camel.springboot.name=SampleCamel
 
 # Uncomment these properties to enable the Camel plugin Trace tab
-#camel.springboot.tracing=true
-#camel.springboot.backlog-tracing=true
-#camel.springboot.use-breadcrumb=true
+#camel.trace.enabled = true
 
 quartz.cron = 0/10 * * * * ?
 quartz.repeatInterval = 10000

--- a/springboot/src/main/resources/application.properties
+++ b/springboot/src/main/resources/application.properties
@@ -23,9 +23,7 @@ logging.level.io.undertow=WARN
 camel.springboot.name=SampleCamel
 
 # Uncomment these properties to enable the Camel plugin Trace tab
-#camel.springboot.tracing=true
-#camel.springboot.backlog-tracing=true
-#camel.springboot.use-breadcrumb=true
+#camel.trace.enabled = true
 
 quartz.cron = 0/10 * * * * ?
 quartz.repeatInterval = 10000


### PR DESCRIPTION
Related: https://github.com/hawtio/hawtio/pull/3917

Updates the trace properties in the examples to use current 4.5 property camel.trace.enabled

https://camel.apache.org/manual/camel-4x-upgrade-guide-4_5.html#_camel_spring_boot